### PR TITLE
Add nixpkgs as a submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-nixpkgs

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "nixpkgs"]
+	path = nixpkgs
+	url = https://github.com/Gricad/nixpkgs.git
+	branch = release-17.09

--- a/CONTRIB_HOWTO.md
+++ b/CONTRIB_HOWTO.md
@@ -12,20 +12,12 @@ Into a directory of your choice:
 
 * Clone your fork:
 
-    ```git clone git@github.com/<user>/nix-ciment-channel.git```
-* Clone nixpkgs of the Gricad fork:
+	```
+	git clone git@github.com/<user>/nix-ciment-channel.git
+	git submodule init
+	git submodule update
+	```
 
-    ```git clone git@github.com/Gricad/nixpkgs```
-* Go into the nixpkgs branch we are currently using:
-```
-  cd nixpkgs
-  git checkout release-17.09
-```
-* Go back into the nix-ciment-channel repository and create a link to nixpkgs
-```
-  cd ../nix-ciment-channel
-  ln -s ../nixpkgs
-```
 * Create a new branch for your work (named for example "my-new-package"):
 
     ```git checkout -b my-new-package```

--- a/README.md
+++ b/README.md
@@ -8,21 +8,12 @@ Set-up
 
 * Clone this repository
 
-    ```git clone https://github.com/Gricad/nix-ciment-channel.git```
+	```
+	git clone https://github.com/Gricad/nix-ciment-channel.git
+	git submodule init
+	git submodule update
+	```
 
-* Clone the nixpkgs repository at the release we are currently using
-
-    ```
-    git clone https://github.com/Gricad/nixpkgs.git
-    cd nixpkgs
-    git checkout release-17.09
-    cd ..
-    ```
-* Link the nixpkgs directory
-    ```
-    cd nix-ciment-channel
-    ln -s ../nixpkgs
-    ```
 
 * You can test to build a package
 


### PR DESCRIPTION
This PR adds the `nixpkgs` repository as a git submodule in the `nix-ciment-channel`. This makes the initial set-up easier (no symlink needed).