### PR TITLE
New CASA version (5.4.0)

### DIFF
--- a/ciment/casa/default.nix
+++ b/ciment/casa/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchurl, glibc, perl, python, xorg, zlib, gcc, fontconfig, freetype, glib, libselinux, libxml2, sqlite, expat, bzip2, libkrb5, gdbm, e2fsprogs }:
+
+stdenv.mkDerivation rec {
+  version = "5.4.0";
+  name = "casa-${version}";
+
+   src = fetchurl {
+    url = "https://casa.nrao.edu/download/distro/linux/release/el7/casa-release-5.4.0-68.el7.tar.gz";
+    sha256 = "16wc17pzrkq3487yfs3pznh5sfaxc60kv7b72a2p3hj9qx23614m";
+  };
+
+  nativeBuildInputs = [ glibc perl python xorg.libSM xorg.libICE xorg.libX11 xorg.libXext xorg.libXi xorg.libXrender xorg.libXrandr xorg.libXfixes xorg.libXcursor xorg.libXinerama xorg.libXft zlib gcc fontconfig glib freetype libselinux libxml2 sqlite expat xorg.libxcb bzip2 libkrb5 gdbm e2fsprogs ];
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" "installCheckPhase" "distPhase" ];
+
+  # We do this manually in the custom postFixup phase
+  dontStrip = true;
+  dontPatchELF = true;
+  dontPatchShebangs = true;
+
+  installPhase = ''
+     cd .. && cp -a $sourceRoot $out
+  '';
+
+  postFixup = ''
+    echo "Fixing rights..."
+    chmod u+w -R $out
+    echo "Patching rpath and interpreter..."
+    find $out -type f -exec $SHELL -c "patchelf --set-rpath ${glibc}/lib:$out/lib:${gcc.cc}/lib:${gcc.cc.lib}/lib:${zlib}/lib:${glib}/lib:${freetype}/lib:${xorg.libSM}/lib:${xorg.libICE}/lib:${xorg.libX11}/lib:${xorg.libXext}/lib:${xorg.libXi}/lib:${xorg.libXrender}/lib:${xorg.libXrandr}/lib:${xorg.libXfixes}/lib:${xorg.libXcursor}/lib:${xorg.libXinerama}/lib:${xorg.libxcb}/lib:${xorg.libXft}/lib:${fontconfig.lib}/lib:${libselinux}/lib:${libxml2.out}/lib:${sqlite.out}/lib:${expat}/lib:$out/etc/carta/lib:${bzip2.out}/lib:${libkrb5}/lib:${gdbm}/lib:${e2fsprogs.out}/lib '{}' 2>/dev/null" \;
+    find $out -type f -exec $SHELL -c "patchelf --set-interpreter $(echo ${glibc}/lib/ld-linux*.so.2) '{}' 2>/dev/null" \;
+    echo "Fixing path into scripts..."
+    for file in `grep -l -r "$sourceRoot" $out`
+    do
+      sed -e "s,$sourceRoot,$out,g" -i $file
+    done 
+    echo "Patching shebangs..."
+    patchShebangs $out
+  '';
+
+  meta = {
+    description = "Casa binary distribution";
+    maintainers = [ stdenv.lib.maintainers.bzizou ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}
+

--- a/default.nix
+++ b/default.nix
@@ -14,8 +14,11 @@ let
     hello = callPackage ./ciment/hello { };
 
     # Casa
+    # Versions 4.7.2 and 5.1.1 are kept for backward
+    # compatibility issues.
     casa-472 = callPackage ./ciment/casa/4.7.2.nix { };
     casa-511 = callPackage ./ciment/casa/5.1.1.nix { };
+    casa = callPackage ./ciment/casa/default.nix { };
 
     # Charliecloud
     charliecloud = callPackage ./ciment/charliecloud { };


### PR DESCRIPTION
This PR updates CASA to the latest upstream (5.4.0). Versions 5.1.1 and 4.7.2 are kept for backward compatibility purposes.